### PR TITLE
Create index-es.html

### DIFF
--- a/languages/index-es.html
+++ b/languages/index-es.html
@@ -1,0 +1,1117 @@
+<html lang="en">
+  <head>
+  <link href="styles.css" rel="stylesheet" integrity="sha256-tzRw9sG0j5bTBpUUfYQIpyNxRltWlSpN/NhCm/gt3uU= sha384-E8vaW4Pc4A8axuRQaTeQ2gYqKRnPLooX3nxx2+McXjeZNrDeaiVRVpUDk28ImOzY" crossorigin="anonymous"></head>
+  <body>
+    <div class="body-wrapper" id="body-wrapper">
+      <header class="header">
+        <div class="container">
+          <div class="header-navbar">
+            <a rel="noopener" class="navbar-logo" href="https://www.mbta.com/">
+              <span class="sr-only">
+                MBTA Página Principal
+              </span>
+              <div class="svg-container" aria-hidden="true">
+                <span class="notranslate c-svg__mbta-logo">
+                  <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 198 36.91016">
+                    <path fill="#1c1e23" d="m18 34.4a16.4 16.4 0 1 1 16.4-16.4 16.34585 16.34585 0 0 1 -16.4 16.4zm0-34.4a18 18 0 1 0 18 18 18.05292 18.05292 0 0 0 -18-18">
+                    </path>
+                    <path fill="#1c1e23" d="m6.6 15.7h8.6v14h5.6v-14h8.6v-5.7h-22.8z">
+                    </path>
+                    <text font-family="Helvetica-Bold, Helvetica" font-size="13.38351" font-weight="700" transform="translate(41.6001 14.41357)">
+                      Massachusetts Bay
+                      <tspan x="0" y="16.06006" letter-spacing="-.05469em">
+                        T
+                      </tspan>
+                      <tspan x="7.44336" y="16.06006" letter-spacing="-.00004em">
+                        ransportation
+                      </tspan>
+                      <tspan x="93.69775" y="16.06006" letter-spacing="-.03663em">
+                      </tspan>
+                      <tspan x="96.92627" y="16.06006">
+                        Authority
+                      </tspan>
+                    </text>
+                  </svg>
+                </span>
+              </div>
+            </a>
+            <button class="navbar-toggle navbar-toggle-mobile collapsed toggle-up-down" aria-expanded="false" type="button" data-toggle="collapse" data-target="#navbar">
+              <span class="nav-link-content">
+                <span class="nav-link-name">
+                  Menú
+                </span>
+                <span class="nav-link-arrows">
+                  <i aria-hidden="true" class="notranslate fa fa-angle-down down">
+                  </i>
+                  <i aria-hidden="true" class="notranslate fa fa-angle-up up">
+                  </i>
+                </span>
+              </span>
+            </button>
+            <nav id="desktop-menu" class="desktop-menu-nav" role="tablist">
+              <div class="pull-right">
+                <div class="nav-item">
+                  <a rel="noopener" aria-controls="gettingAround" class="desktop-nav-link js-header-link collapsed" data-parent="#desktop-menu" data-target="#gettingAround" href="https://www.mbta.com/getting-around" role="tab">
+                    <div class="nav-link-content js-header-link__content">
+                      <span class="nav-link-name">
+                        Moverse
+                      </span>
+                      <div class="nav-link-arrows js-header-link__carets">
+                      </div>
+                    </div>
+                  </a>
+                  <div class="desktop-menu">
+                    <div class="desktop-menu-background-image">
+                      <div class="container">
+                        <div class="desktop-menu-body panel">
+                          <div class="collapse" id="gettingAround" role="tabpanel">
+                            <div class="menu-row">
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Servicios de tránsito
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/schedules/subway">
+                                        Subterraneo
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/schedules/bus">
+                                        Autobús
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/schedules/commuter-rail">
+                                        Tren de cercanías
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/schedules/ferry">
+                                        Transbordador
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/accessibility/the-ride">
+                                        RIDE
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Planea tu viaje
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/trip-planner">
+                                        Planificador de viajes
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/stops">
+                                        Información de la estación
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/alerts">
+                                        Alertas de servicio
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/maps">
+                                        Mapas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/destinations">
+                                        Destinos
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Montando la T
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/accessibility">
+                                        Accesibilidad
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/parking">
+                                        Estacionamiento
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/bikes">
+                                        Bicicletas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/language-services">
+                                        Servicios de idioma
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/safety">
+                                        Seguridad
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="nav-item">
+                  <a rel="noopener" aria-controls="fares" class="desktop-nav-link js-header-link collapsed" data-parent="#desktop-menu" data-target="#fares" href="https://www.mbta.com/fares" role="tab">
+                    <div class="nav-link-content js-header-link__content">
+                      <span class="nav-link-name">
+                        Tarifas
+                      </span>
+                      <div class="nav-link-arrows js-header-link__carets">
+                      </div>
+                    </div>
+                  </a>
+                  <div class="desktop-menu">
+                    <div class="desktop-menu-background-image">
+                      <div class="container">
+                        <div class="desktop-menu-body panel">
+                          <div class="collapse" id="fares" role="tabpanel">
+                            <div class="menu-row">
+                              <div class="col-md-4 col-lg-3 fares-column">
+                                <div class="h5 header-column-heading">
+                                  Más información sobre tarifas
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/fares">
+                                        Resumen de tarifas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener noreferrer" class="ga-nav-sublink" href="https://charliecard.mbta.com" target="_blank">
+                                        Agregue valor a CharlieCard
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/fares/reduced">
+                                        Tarifas reducidas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener noreferrer" class="ga-nav-sublink" href="https://commerce.mbta.com" target="_blank">
+                                        Solicitar pases mensuales
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/pass-program">
+                                        Ventas institucionales
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                              <div class="col-md-8 col-lg-9">
+                                <div class="fare-summary-container fare-summary-container-table-multi-col">
+                                  <div class="fare-summary-row">
+                                    <a rel="noopener" class="fare-summary-entry ga-nav-sublink" href="https://www.mbta.com/fares/subway-fares">
+                                      <div class="fare-summary-title">
+                                        <span class="fare-summary-name">
+                                          Metro, sencillo
+                                        </span>
+                                        <span class="fare-summary-mode-icons">
+                                          <span class="sr-only">
+                                            Válido para:
+                                          </span>
+                                          <span class="sr-only">
+                                            Subterraneo
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Subway">
+                                              <span class="notranslate c-svg__icon-mode-subway-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Subterraneo
+                                                  </title>
+                                                  <path fill="#494f5b" d="m8 0a8 8 0 1 0 8 8 8 8 0 0 0 -8-8">
+                                                  </path>
+                                                  <g fill="#fff">
+                                                    <path d="m6.67 1.41a.56974.56974 0 0 1 .57-.57.58.58 0 1 1 0 1.16h-.02a.57707.57707 0 0 1 -.55-.59z">
+                                                    </path>
+                                                    <path d="m12.01 9.84v-5.91a1.43829 1.43829 0 0 0 -1.44-1.43h-5.13a1.42971 1.42971 0 0 0 -1.43 1.43v5.9a1.88 1.88 0 0 0 1.53 1.85l-1.54 2.32h1.02l1.26-1.84h3.46l1.26 1.84h1l-1.54-2.32a1.8774 1.8774 0 0 0 1.55-1.84zm-5.01-6.93h2v.84h-2zm-.58 8.3a.77.77 0 1 1 .77-.77.77027.77027 0 0 1 -.77.77zm3.15 0a.77.77 0 1 1 0-1.54.77.77 0 1 1 0 1.54zm1.44-4.71a.52279.52279 0 0 1 -.52.52h-4.96a.51641.51641 0 0 1 -.52-.52v-1.96a.51646.51646 0 0 1 .52-.52h4.96a.52284.52284 0 0 1 .52.52z">
+                                                    </path>
+                                                    <path d="m8.19 1.41a.57841.57841 0 0 1 .58-.57.56974.56974 0 0 1 .57.57.57438.57438 0 0 1 -.57.59.58266.58266 0 0 1 -.58-.59z">
+                                                    </path>
+                                                  </g>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                          <span class="sr-only">
+                                            Autobús
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Bus">
+                                              <span class="notranslate c-svg__icon-mode-bus-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Autobús
+                                                  </title>
+                                                  <path fill="#ffc72c" d="m8.03494 0a8.04088 8.04088 0 0 0 -8 8 8 8 0 1 0 8-8">
+                                                  </path>
+                                                  <path fill="#1c1e23" d="m12.55163 6.95515-.43927-3.29782c-.11487-.59469-.50684-.83119-1.088-1.07447a9.94811 9.94811 0 0 0 -2.99371-.52036 9.94139 9.94139 0 0 0 -2.98694.52036c-.57444.24328-.97312.47978-1.09476 1.07447l-.43251 3.29782v4.55476h.80756v.77716a.56688.56688 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.2297a.63557.63557 0 0 0 .669-.58793v-.77716h4.363v.77716a.56686.56686 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.22974a.63556.63556 0 0 0 .669-.58793v-.77716h.74252zm-6.64292-3.93953h4.25065c.20273 0 .37167.23083.37167.50782s-.16894.50781-.37167.50781h-4.25065c-.20272 0-.37167-.23083-.37167-.50781s.16896-.50782.37167-.50782zm-1.03959 4.55438.3006-2.33388a.31412.31412 0 0 1 .32228-.26712h5.12466a.31832.31832 0 0 1 .32226.26712l.34393 2.33388v.10421a.32557.32557 0 0 1 -.3223.32579h-5.7811a.3317.3317 0 0 1 -.31033-.3388.23335.23335 0 0 1 0-.0912zm.6465 2.75347a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432zm5.01541 0a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432z">
+                                                  </path>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div class="fare-summary-box">
+                                        <div class="fare-summary-fare">
+                                          <span class="fare-summary-fare-name">
+                                            CharlieCard, CharlieTicket, o dinero
+                                          </span>
+                                          <span class="fare-summary-fare-price">
+                                            $2.40
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </a>
+                                    <a rel="noopener" class="fare-summary-entry ga-nav-sublink" href="https://www.mbta.com/fares/bus-fares">
+                                      <div class="fare-summary-title">
+                                        <span class="fare-summary-name">
+                                          Autobús local, sencillo
+                                        </span>
+                                        <span class="fare-summary-mode-icons">
+                                          <span class="sr-only">
+                                            Válido para:
+                                          </span>
+                                          <span class="sr-only">
+                                            Autobús    
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Bus">
+                                              <span class="notranslate c-svg__icon-mode-bus-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Autobús
+                                                  </title>
+                                                  <path fill="#ffc72c" d="m8.03494 0a8.04088 8.04088 0 0 0 -8 8 8 8 0 1 0 8-8">
+                                                  </path>
+                                                  <path fill="#1c1e23" d="m12.55163 6.95515-.43927-3.29782c-.11487-.59469-.50684-.83119-1.088-1.07447a9.94811 9.94811 0 0 0 -2.99371-.52036 9.94139 9.94139 0 0 0 -2.98694.52036c-.57444.24328-.97312.47978-1.09476 1.07447l-.43251 3.29782v4.55476h.80756v.77716a.56688.56688 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.2297a.63557.63557 0 0 0 .669-.58793v-.77716h4.363v.77716a.56686.56686 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.22974a.63556.63556 0 0 0 .669-.58793v-.77716h.74252zm-6.64292-3.93953h4.25065c.20273 0 .37167.23083.37167.50782s-.16894.50781-.37167.50781h-4.25065c-.20272 0-.37167-.23083-.37167-.50781s.16896-.50782.37167-.50782zm-1.03959 4.55438.3006-2.33388a.31412.31412 0 0 1 .32228-.26712h5.12466a.31832.31832 0 0 1 .32226.26712l.34393 2.33388v.10421a.32557.32557 0 0 1 -.3223.32579h-5.7811a.3317.3317 0 0 1 -.31033-.3388.23335.23335 0 0 1 0-.0912zm.6465 2.75347a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432zm5.01541 0a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432z">
+                                                  </path>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div class="fare-summary-box">
+                                        <div class="fare-summary-fare">
+                                          <span class="fare-summary-fare-name">
+                                            CharlieCard, CharlieTicket, o dinero
+                                          </span>
+                                          <span class="fare-summary-fare-price">
+                                            $1.70
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </a>
+                                  </div>
+                                  <div class="fare-summary-row">
+                                    <a rel="noopener" class="fare-summary-entry ga-nav-sublink" href="https://www.mbta.com/fares/subway-fares#monthly">
+                                      <div class="fare-summary-title">
+                                        <span class="fare-summary-name">
+                                          LinkPass Mensual
+                                        </span>
+                                        <span class="fare-summary-mode-icons">
+                                          <span class="sr-only">
+                                            Válido para:
+                                          </span>
+                                          <span class="sr-only">
+                                            Subterraneo
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Subway">
+                                              <span class="notranslate c-svg__icon-mode-subway-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Subterraneo
+                                                  </title>
+                                                  <path fill="#494f5b" d="m8 0a8 8 0 1 0 8 8 8 8 0 0 0 -8-8">
+                                                  </path>
+                                                  <g fill="#fff">
+                                                    <path d="m6.67 1.41a.56974.56974 0 0 1 .57-.57.58.58 0 1 1 0 1.16h-.02a.57707.57707 0 0 1 -.55-.59z">
+                                                    </path>
+                                                    <path d="m12.01 9.84v-5.91a1.43829 1.43829 0 0 0 -1.44-1.43h-5.13a1.42971 1.42971 0 0 0 -1.43 1.43v5.9a1.88 1.88 0 0 0 1.53 1.85l-1.54 2.32h1.02l1.26-1.84h3.46l1.26 1.84h1l-1.54-2.32a1.8774 1.8774 0 0 0 1.55-1.84zm-5.01-6.93h2v.84h-2zm-.58 8.3a.77.77 0 1 1 .77-.77.77027.77027 0 0 1 -.77.77zm3.15 0a.77.77 0 1 1 0-1.54.77.77 0 1 1 0 1.54zm1.44-4.71a.52279.52279 0 0 1 -.52.52h-4.96a.51641.51641 0 0 1 -.52-.52v-1.96a.51646.51646 0 0 1 .52-.52h4.96a.52284.52284 0 0 1 .52.52z">
+                                                    </path>
+                                                    <path d="m8.19 1.41a.57841.57841 0 0 1 .58-.57.56974.56974 0 0 1 .57.57.57438.57438 0 0 1 -.57.59.58266.58266 0 0 1 -.58-.59z">
+                                                    </path>
+                                                  </g>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                          <span class="sr-only">
+                                            Autobús
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Bus">
+                                              <span class="notranslate c-svg__icon-mode-bus-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Autobús
+                                                  </title>
+                                                  <path fill="#ffc72c" d="m8.03494 0a8.04088 8.04088 0 0 0 -8 8 8 8 0 1 0 8-8">
+                                                  </path>
+                                                  <path fill="#1c1e23" d="m12.55163 6.95515-.43927-3.29782c-.11487-.59469-.50684-.83119-1.088-1.07447a9.94811 9.94811 0 0 0 -2.99371-.52036 9.94139 9.94139 0 0 0 -2.98694.52036c-.57444.24328-.97312.47978-1.09476 1.07447l-.43251 3.29782v4.55476h.80756v.77716a.56688.56688 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.2297a.63557.63557 0 0 0 .669-.58793v-.77716h4.363v.77716a.56686.56686 0 0 0 .29735.48655c.04054.02029.08109.04054.11487.05407a.689.689 0 0 0 .09462.027.57561.57561 0 0 0 .15546.02029h.22974a.63556.63556 0 0 0 .669-.58793v-.77716h.74252zm-6.64292-3.93953h4.25065c.20273 0 .37167.23083.37167.50782s-.16894.50781-.37167.50781h-4.25065c-.20272 0-.37167-.23083-.37167-.50781s.16896-.50782.37167-.50782zm-1.03959 4.55438.3006-2.33388a.31412.31412 0 0 1 .32228-.26712h5.12466a.31832.31832 0 0 1 .32226.26712l.34393 2.33388v.10421a.32557.32557 0 0 1 -.3223.32579h-5.7811a.3317.3317 0 0 1 -.31033-.3388.23335.23335 0 0 1 0-.0912zm.6465 2.75347a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432zm5.01541 0a.82854.82854 0 1 1 -.03709-1.65432.83107.83107 0 1 1 .03709 1.65432z">
+                                                  </path>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div class="fare-summary-box">
+                                        <div class="fare-summary-fare">
+                                          <span class="fare-summary-fare-name">
+                                            CharlieCard o CharlieTicket
+                                          </span>
+                                          <span class="fare-summary-fare-price">
+                                            $90.00
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </a>
+                                    <a rel="noopener" class="fare-summary-entry ga-nav-sublink" href="https://www.mbta.com/fares/commuter-rail-fares">
+                                      <div class="fare-summary-title">
+                                        <span class="fare-summary-name">
+                                          Tren de cercanías, sencillo
+                                        </span>
+                                        <span class="fare-summary-mode-icons">
+                                          <span class="sr-only">
+                                            Válido para:
+                                          </span>
+                                          <span class="sr-only">
+                                            Tren de cercanías
+                                          </span>
+                                          <span class="fares-mode-icon-group" aria-hidden="true">
+                                            <span data-toggle="tooltip" title="Commuter Rail">
+                                              <span class="notranslate c-svg__icon-mode-commuter-rail-small">
+                                                <svg xmlns="http://www.w3.org/2000/svg" role="img" viewbox="0 0 16 16">
+                                                  <title>
+                                                    Tren de cercanías
+                                                  </title>
+                                                  <path fill="#80276c" d="m6.19 11.91998h3.63v1h-3.63z" transform="matrix(.99919448 .0401297 -.0401297 .99919448 .50486 -.31123)">
+                                                  </path>
+                                                  <path fill="#80276c" d="m8 0a8.02127 8.02127 0 0 0 -7.65785 10.376 7.78359 7.78359 0 0 0 5.28185 5.28185 8.008 8.008 0 1 0 2.376-15.65785">
+                                                  </path>
+                                                  <g fill="#fff">
+                                                    <path d="m10.33 11.75 1.15-.85a1.46975 1.46975 0 0 0 .52-.84v-4.82a.88891.88891 0 0 0 -.3-.66.79321.79321 0 0 1 -.31-.6l-.01-1.19a.81979.81979 0 0 0 -.65-.79 20.91806 20.91806 0 0 0 -2.5-.52 1.06538 1.06538 0 0 0 -.47 0c-.7.15-1.55.3-2.24.48-.42.12-.85.35-.85.85v1.18a.80288.80288 0 0 1 -.33.61.851.851 0 0 0 -.31.66v4.8a1.40971 1.40971 0 0 0 .48.84l1.1.81-1.74 2.84h1.13l.24-.39h5.53l.13.22.02.03.08.14h1.05zm.95-2.3a.73.73 0 1 1 -.73-.73.72767.72767 0 0 1 .73.73zm-1.44 3.15h-3.65l.41-.68h2.84l.03.06.35.58zm-1.14-9.65a.24471.24471 0 0 1 .3-.24l1.21.25a.25351.25351 0 0 1 .2.24v.73a.24955.24955 0 0 1 -.3.24l-1.21-.24a.23758.23758 0 0 1 -.2-.24zm-.72 2.26a.82.82 0 1 1 -.82.82.82371.82371 0 0 1 .82-.82zm-2.32-2.01a.25358.25358 0 0 1 .2-.24l1.21-.25a.24868.24868 0 0 1 .3.24v.74a.24683.24683 0 0 1 -.2.24l-1.22.24a.24554.24554 0 0 1 -.29-.24zm-.2 6.98a.73.73 0 1 1 .73-.73.72767.72767 0 0 1 -.73.73zm0 3.61.5-.82h4.1l.49.82z">
+                                                    </path>
+                                                    <path d="m11 14.55h-.01l-.07-.14z">
+                                                    </path>
+                                                  </g>
+                                                </svg>
+                                              </span>
+                                            </span>
+                                          </span>
+                                        </span>
+                                      </div>
+                                      <div class="fare-summary-box">
+                                        <div class="fare-summary-fare">
+                                          <span class="fare-summary-fare-name">
+                                            Zonas 1A-10
+                                          </span>
+                                          <span class="fare-summary-fare-price">
+                                            $2.40 – $13.25
+                                          </span>
+                                        </div>
+                                      </div>
+                                    </a>
+                                  </div>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="nav-item">
+                  <a rel="noopener" aria-controls="contactUs" class="desktop-nav-link js-header-link collapsed" data-parent="#desktop-menu" data-target="#contactUs" href="https://www.mbta.com/customer-support" role="tab">
+                    <div class="nav-link-content js-header-link__content">
+                      <span class="nav-link-name">
+                        Contáctenos
+                      </span>
+                      <div class="nav-link-arrows js-header-link__carets">
+                      </div>
+                    </div>
+                  </a>
+                  <div class="desktop-menu">
+                    <div class="desktop-menu-background-image">
+                      <div class="container">
+                        <div class="desktop-menu-body panel">
+                          <div class="collapse" id="contactUs" role="tabpanel">
+                            <div class="menu-row">
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Atención al cliente
+                                </div>
+                                <p>
+                                  <a href="tel:+1-617-222-3200">
+                                    617-222-3200
+                                  </a>
+                                  <br/>
+                                  <strong>
+                                    TTY
+                                  </strong>
+                                  <a href="tel:+1-617-222-5146">
+                                    617-222-5146
+                                  </a>
+                                  <br/>
+                                  <strong>
+                                    Lunes — Viernes:
+                                  </strong>
+                                  6:30A hasta 8:00P
+                                  <br/>
+                                  <strong>
+                                    Sabado — Domingo:
+                                  </strong>
+                                  8:00A hasta 4:00P
+                                  <br/>
+                                </p>
+                                <ul>
+                                  <li>
+                                    <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/customer-support">
+                                      Envíanos tus comentarios o preguntas
+                                    </a>
+                                  </li>
+                                  <li>
+                                    <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/customer-support#customer_support">
+                                      Ver todos los números de contacto
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Policía de tránsito
+                                </div>
+                                <p>
+                                  <strong>
+                                    Emergencia:
+                                  </strong>
+                                  <a href="tel:+1-617-222-1212">
+                                    617-222-1212
+                                  </a>
+                                  <br/>
+                                  <strong>
+                                    TTY:
+                                  </strong>
+                                  <a href="tel:+1-617-222-1200">
+                                    617-222-1200
+                                  </a>
+                                  <br/>
+                                </p>
+                                <ul>
+                                  <li>
+                                    <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/transit-police">
+                                      Comuníquese con la Policía de Tránsito
+                                    </a>
+                                  </li>
+                                  <li>
+                                    <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/transit-police/see-something-say-something">
+                                      Ver algo, decir algo
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Actualizaciones del servicio
+                                </div>
+                                <p>
+                                  Reciba notificaciones de alertas del servicio MBTA por correo electrónico o mensaje de texto (SMS).
+                                </p>
+                                <ul>
+                                  <li>
+                                    <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/about-t-alerts">
+                                      Acerca de las alertas T
+                                    </a>
+                                  </li>
+                                  <li>
+                                    <a rel="noopener noreferrer" class="ga-nav-sublink" href="https://alerts.mbta.com" target="_blank">
+                                      Regístrese para recibir alertas T
+                                    </a>
+                                  </li>
+                                  <li>
+                                    <a rel="noopener noreferrer" class="ga-nav-sublink" href="https://twitter.com/MBTA" target="_blank">
+                                     Actualizaciones de Twitter @MBTA 
+                                    </a>
+                                  </li>
+                                </ul>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="nav-item">
+                  <a rel="noopener" aria-controls="more" class="desktop-nav-link js-header-link collapsed" data-parent="#desktop-menu" data-target="#more" href="https://www.mbta.com/about" role="tab">
+                    <div class="nav-link-content js-header-link__content">
+                      <span class="nav-link-name">
+                        Más
+                      </span>
+                      <div class="nav-link-arrows js-header-link__carets">
+                      </div>
+                    </div>
+                  </a>
+                  <div class="desktop-menu">
+                    <div class="desktop-menu-background-image">
+                      <div class="container">
+                        <div class="desktop-menu-body panel">
+                          <div class="collapse" id="more" role="tabpanel">
+                            <div class="menu-row">
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Sobre nosotros
+                                </div>
+                                <div class="row">
+                                  <div class="col-xs-6">
+                                    <ul>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/mbta-at-a-glance">
+                                          Descripción general
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/leadership">
+                                          Liderazgo
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/news">
+                                         Actualización de las noticias 
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/events">
+                                          Eventos
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                  <div class="col-xs-6">
+                                    <ul>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/policies/title-vi">
+                                          Derechos Civiles
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener noreferrer" class="ga-nav-sublink" href="http://www.mbtabackontrack.com/performance/index.html#/home" target="_blank">
+                                          <span class="no-wrap">
+                                            Rendimiento
+                                          </span>
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/sustainability">
+                                          <span class="no-wrap">
+                                            Sustentabilidad
+                                          </span>
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/history">
+                                          Historia
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener noreferrer" class="ga-nav-sublink" href="http://www.mbtagifts.com/" target="_blank">
+                                          Regalos
+                                        </a>
+                                      </li>
+                                      <li>
+                                        <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/careers">
+                                          Carreras
+                                        </a>
+                                      </li>
+                                    </ul>
+                                  </div>
+                                </div>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Centro de negocios
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/business">
+                                        Oportunidades de negocio
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/developers">
+                                        Desarrolladores
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/financials">
+                                        Finanzas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/innovation">
+                                        Innovación
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                              <div class="col-xs-4 header-column">
+                                <div class="h5 header-column-heading">
+                                  Mejoras y Proyectos
+                                </div>
+                                <div class="col-xs-12 p-a-0">
+                                  <ul>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/projects/building-better-t-2020">
+                                        Construyendo una mejor T
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/projects/commuter-rail-positive-train-control-ptc">
+                                        Control positivo del tren de cercanías
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/fare-transformation">
+                                        Transformación de tarifas
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener noreferrer" class="ga-nav-sublink" href="https://www.mbta.com/projects/green-line-transformation" target="_blank">
+                                        Transformación de la línea verde
+                                      </a>
+                                    </li>
+                                    <li>
+                                      <a rel="noopener" class="ga-nav-sublink" href="https://www.mbta.com/projects">
+                                        Ver todos los proyectos
+                                      </a>
+                                    </li>
+                                  </ul>
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="nav-item">
+                  <a rel="noopener" class="desktop-nav-link navbar-toggle collapsed toggle-up-down" href="https://www.mbta.com/search" role="tab">
+                    <div class="nav-link-content">
+                      <span class="nav-link-name">
+                        Búsqueda
+                      </span>
+                      <span class="nav-search-icon">
+                        <svg version="1.1" width="30" height="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon icon-search " viewbox="6 -4 95 95" preserveaspectratio="xMidYMid meet" title="">
+                          <g fill-rule="evenodd" class="notranslate icon-image icon-search-image">
+                            <path d="m 57.396003,7.8603731 c 18.708661,0 34.015747,15.2716529 34.015747,33.9803139 0,18.708661 -15.307086,34.015748 -34.015747,34.015748 -7.192914,0 -13.854331,-2.30315 -19.346457,-6.129921 l -18.389763,18.35433 c -2.338583,2.374016 -6.165354,2.374016 -8.503937,0 -2.338582,-2.338583 -2.338582,-6.129921 0,-8.468504 L 29.54561,61.222577 c -3.862205,-5.527559 -6.129922,-12.188976 -6.129922,-19.38189 0,-18.708661 15.307087,-33.9803139 33.980315,-33.9803139 z m 0,11.9763779 c -12.188976,0 -21.968504,9.779527 -21.968504,22.003936 0,12.22441 9.779528,22.003937 21.968504,22.003937 12.224409,0 22.003936,-9.779527 22.003936,-22.003937 0,-12.224409 -9.779527,-22.003936 -22.003936,-22.003936 z">
+                            </path>
+                          </g>
+                        </svg>
+                      </span>
+                    </div>
+                  </a>
+                </div>
+              </div>
+            </nav>
+          </div>
+          <nav class="collapse row" id="navbar" role="navigation">
+            <ul class="mobile-nav">
+              <li class="mobile-nav-item search-mobile">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/search">
+                  <span class="mobile-nav-item-header">
+                    <svg version="1.1" width="30" height="30" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" class="icon icon-search " viewbox="6 -4 95 95" preserveaspectratio="xMidYMid meet" title="">
+                      <g fill-rule="evenodd" class="notranslate icon-image icon-search-image">
+                        <path d="m 57.396003,7.8603731 c 18.708661,0 34.015747,15.2716529 34.015747,33.9803139 0,18.708661 -15.307086,34.015748 -34.015747,34.015748 -7.192914,0 -13.854331,-2.30315 -19.346457,-6.129921 l -18.389763,18.35433 c -2.338583,2.374016 -6.165354,2.374016 -8.503937,0 -2.338582,-2.338583 -2.338582,-6.129921 0,-8.468504 L 29.54561,61.222577 c -3.862205,-5.527559 -6.129922,-12.188976 -6.129922,-19.38189 0,-18.708661 15.307087,-33.9803139 33.980315,-33.9803139 z m 0,11.9763779 c -12.188976,0 -21.968504,9.779527 -21.968504,22.003936 0,12.22441 9.779528,22.003937 21.968504,22.003937 12.224409,0 22.003936,-9.779527 22.003936,-22.003937 0,-12.224409 -9.779527,-22.003936 -22.003936,-22.003936 z">
+                        </path>
+                      </g>
+                    </svg>
+                    <span>
+                      Búsqueda
+                    </span>
+                  </span>
+                </a>
+              </li>
+              <li class="mobile-nav-item">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/">
+                  <span class="mobile-nav-item-header">
+                    <strong>
+                      Página Principal
+                    </strong>
+                  </span>
+                  <p class="mobile-nav-description">
+                  </p>
+                </a>
+              </li>
+              <li class="mobile-nav-item">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/getting-around">
+                  <span class="mobile-nav-item-header">
+                    Moverse
+                  </span>
+                  <p class="mobile-nav-description">
+                    Servicios de tránsito, planifique tu viaje, viaje...
+                  </p>
+                </a>
+              </li>
+              <li class="mobile-nav-item">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/fares">
+                  <span class="mobile-nav-item-header">
+                    Tarifas
+                  </span>
+                  <p class="mobile-nav-description">
+                    Tarifas por modalidad, tarifas reducidas, pases...
+                  </p>
+                </a>
+              </li>
+              <li class="mobile-nav-item">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/customer-support">
+                  <span class="mobile-nav-item-header">
+                    Contáctenos
+                  </span>
+                  <p class="mobile-nav-description">
+                    Soporte telefónico y en linea, Alertas T
+                  </p>
+                </a>
+              </li>
+              <li class="mobile-nav-item">
+                <a rel="noopener" class="mobile-nav-link" href="https://www.mbta.com/about">
+                  <span class="mobile-nav-item-header">
+                    Más
+                  </span>
+                  <p class="mobile-nav-description">
+                    Quienes somos, centro de negocios, proyectos...
+                  </p>
+                </a>
+              </li>
+            </ul>
+          </nav>
+        </div>
+      </header>
+      <!--Robert Stopped Translating Here-->
+      <footer class="m-footer l-footer">
+        <div class="container">
+          <ul class="row list-unstyled">
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Transit Services
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/schedules/subway">
+                    Subway
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/schedules/bus">
+                    Bus
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/schedules/commuter-rail">
+                    Commuter Rail
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/schedules/ferry">
+                    Ferry
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/accessibility/the-ride">
+                    The RIDE
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Plan Your Journey
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/trip-planner">
+                    Trip Planner
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/stops">
+                    Station Info
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/alerts">
+                    Service Alerts
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/maps">
+                    Maps
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/destinations">
+                    Destinations
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Riding the T
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/accessibility">
+                    Accessibility
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/parking">
+                    Parking
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/bikes">
+                    Bikes
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/language-services">
+                    Language Services
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/safety">
+                    Safety
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Fares &amp; Passes
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/fares">
+                    Fares Overview
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener noreferrer" href="https://charliecard.mbta.com" target="_blank">
+                    Add Value to CharlieCard
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/fares/reduced">
+                    Reduced Fares
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener noreferrer" href="https://commerce.mbta.com" target="_blank">
+                    Order Monthly Passes
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/pass-program">
+                    Institutional Sales
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                About Us
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/leadership">
+                    Leadership
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/news">
+                    News &amp; Updates
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/events">
+                    Events
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener noreferrer" href="http://www.mbtabackontrack.com/performance/index.html#/home" target="_blank">
+                    Performance
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/careers">
+                    Careers
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Business Center
+              </div>
+              <ul class="list-unstyled">
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/business">
+                    Business Opportunities
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/developers">
+                    Developers
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" data-scroll="true" href="https://www.mbta.com/financials">
+                    Financials
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/innovation">
+                    Innovation
+                  </a>
+                </li>
+                <li class="m-footer__item">
+                  <a rel="noopener" href="https://www.mbta.com/engineering/design-standards-and-guidelines">
+                    Engineering Design Standards
+                  </a>
+                </li>
+              </ul>
+            </li>
+            <li class="m-footer__group m-footer--mobile__group">
+              <div class="m-footer__group-title">
+                Customer Support
+              </div>
+              <ul class="list-unstyled">
+                <div class="m-footer--mobile__items">
+                  <li class="m-footer__item m-footer--mobile__item">
+                    <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
+                      Contact Us
+                    </a>
+                  </li>
+                  <li class="m-footer__item m-footer--mobile__item">
+                    <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
+                      Lost and Found
+                    </a>
+                  </li>
+                  <li class="m-footer__item m-footer--mobile__item">
+                    <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
+                      Policies
+                    </a>
+                  </li>
+                </div>
+                <div class="hidden-sm-down">
+                  <li class="m-footer__item">
+                    <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
+                      Request Public Records
+                    </a>
+                  </li>
+                  <li class="m-footer__item">
+                    <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
+                      Civil Rights
+                    </a>
+                  </li>
+                </div>
+              </ul>
+            </li>
+            <li class="m-footer__group">
+              <div class="m-footer__group-title">
+                Follow Us Online
+              </div>
+              <ul class="c-social">
+                <li class="c-social__item m-footer__item">
+                  <a rel="noopener noreferrer" class="c-social__link c-social--facebook" href="https://www.facebook.com/TheMBTA/" target="_blank">
+                    <i aria-hidden="true" class="notranslate fa fa-facebook ">
+                    </i>
+                    <span class="sr-only">
+                      MBTA Facebook
+                    </span>
+                  </a>
+                </li>
+                <li class="c-social__item m-footer__item">
+                  <a rel="noopener noreferrer" class="c-social__link c-social--instagram" href="https://www.instagram.com/thembta/" target="_blank">
+                    <i aria-hidden="true" class="notranslate fa fa-instagram ">
+                    </i>
+                    <span class="sr-only">
+                      MBTA Instagram
+                    </span>
+                  </a>
+                </li>
+                <li class="c-social__item m-footer__item">
+                  <a rel="noopener noreferrer" class="c-social__link c-social--linkedin" href="https://linkedin.com/company/mbta" target="_blank">
+                    <i aria-hidden="true" class="notranslate fa fa-linkedin ">
+                    </i>
+                    <span class="sr-only">
+                      MBTA Linkedin
+                    </span>
+                  </a>
+                </li>
+                <li class="c-social__item m-footer__item">
+                  <a rel="noopener noreferrer" class="c-social__link c-social--twitter" href="https://twitter.com/MBTA" target="_blank">
+                    <i aria-hidden="true" class="notranslate fa fa-twitter ">
+                    </i>
+                    <span class="sr-only">
+                      MBTA Twitter
+                    </span>
+                  </a>
+                </li>
+                <li class="c-social__item m-footer__item">
+                  <a rel="noopener noreferrer" class="c-social__link c-social--youtube" href="https://www.youtube.com/user/mbtagm/" target="_blank">
+                    <i aria-hidden="true" class="notranslate fa fa-youtube ">
+                    </i>
+                    <span class="sr-only">
+                      MBTA Youtube
+                    </span>
+                  </a>
+                </li>
+              </ul>
+            </li>
+          </ul>
+          <p class="m-footer__copyright">
+            © Massachusetts Bay Transportation Authority, all rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  <script src="script.js" integrity="sha256-PsDxHHyZYWAmTWrz8x4r/F+2dM/LyvjALa0Ubac0K2w= sha384-+oV+phdpyPN7c3EkFb2ruX2C2StZybhiY/TvpSqTFMM8ZAI/MWUqbiBGZmZuXszp" crossorigin="anonymous"></script></body>
+</html>


### PR DESCRIPTION
Translated header (not subheader) into Spanish. Tried to follow Google translations where possible, made a small number of corrections where the machine translation would cause confusion:

Let me know if this is how you imagined this working. If so, I'll do the subheader + footer next. 

CHANGES MADE VS GOOGLE TRANSLATE:

“Ferry” originally appeared as “Transportar.” This is incorrect, as that is the verb for “to ferry” as in “to bring.” Updated to “transbordador”

-“Unidireccional” is pretty weird. That's like a train that can only go one way, not a one-way trip.  Updated to “sencillo”

-¨Business center¨ was not translated at all in mobile header. Translated to "centro de negocios", which appears elsewhere.