### PR TITLE
Remove unnecessary divs

### DIFF
--- a/languages/footer-es.html
+++ b/languages/footer-es.html
@@ -197,36 +197,32 @@
         <div class="m-footer__group-title">
           Atención al cliente
         </div>
-        <ul class="list-unstyled">
-          <div class="m-footer--mobile__items">
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
-                Contáctenos
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
-                Objetos perdidos
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
-                Políticas
-              </a>
-            </li>
-          </div>
-          <div class="hidden-sm-down">
-            <li class="m-footer__item">
-              <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
-                Solicitar registros públicos
-              </a>
-            </li>
-            <li class="m-footer__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
-                Derechos civiles
-              </a>
-            </li>
-          </div>
+        <ul class="list-unstyled m-footer--mobile__items">
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
+              Contáctenos
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
+              Objetos perdidos
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
+              Políticas
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
+              Solicitar registros públicos
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
+              Derechos civiles
+            </a>
+          </li>
         </ul>
       </li>
       <li class="m-footer__group">

--- a/languages/footer-pt.html
+++ b/languages/footer-pt.html
@@ -197,36 +197,32 @@
         <div class="m-footer__group-title">
           Suporte ao cliente
         </div>
-        <ul class="list-unstyled">
-          <div class="m-footer--mobile__items">
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
-                Entre em contato conosco
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
-                Achados e perdidos
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
-                Políticas
-              </a>
-            </li>
-          </div>
-          <div class="hidden-sm-down">
-            <li class="m-footer__item">
-              <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
-                Solicitar registros públicos
-              </a>
-            </li>
-            <li class="m-footer__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
-                Direitos civis
-              </a>
-            </li>
-          </div>
+        <ul class="list-unstyled m-footer--mobile__items">
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
+              Entre em contato conosco
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
+              Achados e perdidos
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
+              Políticas
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
+              Solicitar registros públicos
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
+              Direitos civis
+            </a>
+          </li>
         </ul>
       </li>
       <li class="m-footer__group">

--- a/languages/footer-zh-cn.html
+++ b/languages/footer-zh-cn.html
@@ -197,36 +197,32 @@
         <div class="m-footer__group-title">
           客户支持
         </div>
-        <ul class="list-unstyled">
-          <div class="m-footer--mobile__items">
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
-                联系我们
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
-                失物招领
-              </a>
-            </li>
-            <li class="m-footer__item m-footer--mobile__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
-                政策
-              </a>
-            </li>
-          </div>
-          <div class="hidden-sm-down">
-            <li class="m-footer__item">
-              <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
-                公共请求记录
-              </a>
-            </li>
-            <li class="m-footer__item">
-              <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
-                公民权利
-              </a>
-            </li>
-          </div>
+        <ul class="list-unstyled m-footer--mobile__items">
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support">
+              联系我们
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/customer-support/lost-and-found">
+              失物招领
+            </a>
+          </li>
+          <li class="m-footer__item m-footer--mobile__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies">
+              政策
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener noreferrer" href="https://massachusettsdot.mycusthelp.com/WEBAPP/_rs/supporthome.aspx?lp=3&amp;COID=64D93B66" target="_blank">
+              公共请求记录
+            </a>
+          </li>
+          <li class="m-footer__item">
+            <a rel="noopener" data-scroll="true" href="https://www.mbta.com/policies/title-vi">
+              公民权利
+            </a>
+          </li>
         </ul>
       </li>
       <li class="m-footer__group">


### PR DESCRIPTION
Google Translate introduced new divs into the Customer Support column of footer that aren't present in the production site or the webpack-generated HTML fragment. IHCD flagged these divs as an accessibility issue. 

This removes those enclosing divs and moves the `m-footer--mobile__items` class back up to the `<ul>`.